### PR TITLE
Slow down no-response.

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -20,7 +20,7 @@ jobs:
         # done by `github-actions[bot]` as the `no-response` Action needs to be compiled.
         with:
           token: ${{ github.token }}
-          daysUntilClose: 14
+          daysUntilClose: 42
           responseRequiredLabel: 'awaiting-reply'
           closeComment: >
                 This issue has been automatically closed because there has been no response


### PR DESCRIPTION
Fourteen days isn't very long to respond to a request for more information, especially given it may come in weeks, months or years after the original request.

Vacations last longer than time. Development crunches last longer than that.

Let's give them 6 weeks before the bot gets upset.

[I am preparing to share this script across Kivy projects.]

<!--
Thank you for pull request.

Below are items maintainers should consider when merging the PR. Feel free to suggest a `unit@` label or check-mark the others as appropriate.

-->
Maintainer merge checklist
* [ ] Title is descriptive/clear for inclusion in release notes.
* [ ] Applied a `Component: xxx` label.
* [ ] Applied the `api-deprecation` or `api-break` label.
* [ ] Applied the `release-highlight` label to be highlighted in release notes.
* [ ] Added to the milestone version it was merged into.
* [ ] **Unittests** are included in PR.
* [ ] Properly documented, including `versionadded`, `versionchanged` as needed.
